### PR TITLE
can disable animation/action/vibration

### DIFF
--- a/library/src/commonMain/kotlin/me/saket/swipe/SwipeAction.kt
+++ b/library/src/commonMain/kotlin/me/saket/swipe/SwipeAction.kt
@@ -30,7 +30,9 @@ class SwipeAction(
   val icon: @Composable () -> Unit,
   val background: Color,
   val weight: Double = 1.0,
-  val isUndo: Boolean = false
+  val isUndo: Boolean = false,
+  val enableAnimation: Boolean = true,
+  val enableAct: Boolean = true,
 ) {
   init {
     require(weight > 0.0) { "invalid weight $weight; must be greater than zero" }
@@ -42,12 +44,16 @@ class SwipeAction(
     background: Color = this.background,
     weight: Double = this.weight,
     isUndo: Boolean = this.isUndo,
+    enableAnimation: Boolean = this.enableAnimation,
+    enableAct: Boolean = this.enableAct,
   ) = SwipeAction(
     onSwipe = onSwipe,
     icon = icon,
     background = background,
     weight = weight,
-    isUndo = isUndo
+    isUndo = isUndo,
+    enableAnimation = enableAnimation,
+    enableAct = enableAct,
   )
 }
 
@@ -59,7 +65,9 @@ fun SwipeAction(
   icon: Painter,
   background: Color,
   weight: Double = 1.0,
-  isUndo: Boolean = false
+  isUndo: Boolean = false,
+  enableAnimation: Boolean = true,
+  enableAct: Boolean = true,
 ): SwipeAction {
   return SwipeAction(
     icon = {
@@ -72,6 +80,8 @@ fun SwipeAction(
     background = background,
     weight = weight,
     onSwipe = onSwipe,
-    isUndo = isUndo
+    isUndo = isUndo,
+    enableAnimation = enableAnimation,
+    enableAct = enableAct,
   )
 }

--- a/library/src/commonMain/kotlin/me/saket/swipe/SwipeAction.kt
+++ b/library/src/commonMain/kotlin/me/saket/swipe/SwipeAction.kt
@@ -33,6 +33,7 @@ class SwipeAction(
   val isUndo: Boolean = false,
   val enableAnimation: Boolean = true,
   val enableAct: Boolean = true,
+  val enableVibration: Boolean = enableAct,
 ) {
   init {
     require(weight > 0.0) { "invalid weight $weight; must be greater than zero" }
@@ -46,6 +47,7 @@ class SwipeAction(
     isUndo: Boolean = this.isUndo,
     enableAnimation: Boolean = this.enableAnimation,
     enableAct: Boolean = this.enableAct,
+    enableVibration: Boolean = this.enableVibration,
   ) = SwipeAction(
     onSwipe = onSwipe,
     icon = icon,
@@ -54,6 +56,7 @@ class SwipeAction(
     isUndo = isUndo,
     enableAnimation = enableAnimation,
     enableAct = enableAct,
+    enableVibration = enableVibration,
   )
 }
 
@@ -68,6 +71,7 @@ fun SwipeAction(
   isUndo: Boolean = false,
   enableAnimation: Boolean = true,
   enableAct: Boolean = true,
+  enableVibration: Boolean = enableAct,
 ): SwipeAction {
   return SwipeAction(
     icon = {
@@ -83,5 +87,6 @@ fun SwipeAction(
     isUndo = isUndo,
     enableAnimation = enableAnimation,
     enableAct = enableAct,
+    enableVibration = enableVibration,
   )
 }

--- a/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsBox.kt
+++ b/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsBox.kt
@@ -125,11 +125,11 @@ private fun ActionIconBox(
         layout(width = placeable.width, height = placeable.height) {
           // Align icon with the left/right edge of the content being swiped.
           val iconOffset = if (action.isOnRightSide) constraints.maxWidth + offset else offset - placeable.width
-          placeable.placeRelative(x = iconOffset.roundToInt(), y = 0)
+          placeable.place(x = iconOffset.roundToInt(), y = 0)
         }
       }
       .background(color = backgroundColor),
-    horizontalArrangement = if (action.isOnRightSide) Arrangement.Start else Arrangement.End,
+    horizontalArrangement = if (action.isOnRightSide) Arrangement.Absolute.Left else Arrangement.Absolute.Right,
     verticalAlignment = Alignment.CenterVertically,
   ) {
     content()

--- a/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsBox.kt
+++ b/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsBox.kt
@@ -109,7 +109,7 @@ fun SwipeableActionsBox(
 
   val hapticFeedback = LocalHapticFeedback.current
   // I am not sure, but the `swipedAction == null` should means drag going ahead, if non-null meas going back, so, going ahead will vibrate, going back will not.
-  if (state.swipedAction == null && state.visibleAction?.value?.enableAnimation == true && state.hasCrossedSwipeThreshold()) {
+  if (state.swipedAction == null && state.visibleAction?.value?.enableVibration == true && state.hasCrossedSwipeThreshold()) {
     LaunchedEffect(state.visibleAction) {
       hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
     }

--- a/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsState.kt
+++ b/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsState.kt
@@ -56,8 +56,8 @@ class SwipeableActionsState internal constructor() {
   internal val draggableState = DraggableState { delta ->
     val targetOffset = offsetState.value + delta
 
-    val canSwipeTowardsRight = actions.left.isNotEmpty() && visibleAction?.value?.enableAct == true
-    val canSwipeTowardsLeft = actions.right.isNotEmpty() && visibleAction?.value?.enableAct == true
+    val canSwipeTowardsRight = actions.left.isNotEmpty()
+    val canSwipeTowardsLeft = actions.right.isNotEmpty()
 
     val isAllowed = isResettingOnRelease
       || targetOffset == 0f
@@ -99,6 +99,8 @@ class SwipeableActionsState internal constructor() {
             dragBy(value - offsetState.value)
           }
         }
+      }else {  // no animation, reset offset to 0 when drag stopped
+        offsetState.value = 0f
       }
 
       swipedAction = null

--- a/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsState.kt
+++ b/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsState.kt
@@ -56,14 +56,17 @@ class SwipeableActionsState internal constructor() {
   internal val draggableState = DraggableState { delta ->
     val targetOffset = offsetState.value + delta
 
-    val canSwipeTowardsRight = actions.left.isNotEmpty()
-    val canSwipeTowardsLeft = actions.right.isNotEmpty()
+    val canSwipeTowardsRight = actions.left.isNotEmpty() && visibleAction?.value?.enableAct == true
+    val canSwipeTowardsLeft = actions.right.isNotEmpty() && visibleAction?.value?.enableAct == true
 
     val isAllowed = isResettingOnRelease
       || targetOffset == 0f
       || (targetOffset > 0f && canSwipeTowardsRight)
       || (targetOffset < 0f && canSwipeTowardsLeft)
-    offsetState.value += if (isAllowed) delta else delta / 10
+
+    offsetState.value += if(isResettingOnRelease.not() && visibleAction?.value?.enableAnimation == false) 0f
+    else if (isAllowed) delta
+    else (delta / 10)
   }
 
   internal fun hasCrossedSwipeThreshold(): Boolean {
@@ -71,15 +74,24 @@ class SwipeableActionsState internal constructor() {
   }
 
   internal suspend fun handleOnDragStopped() = coroutineScope {
+    // if disable animation will not be able to determine swiped by offset
+    val cantDetermineSwiped = visibleAction?.value?.enableAnimation == false
+    val actEnabled = visibleAction?.value?.enableAct == true
+
     launch {
-      if (hasCrossedSwipeThreshold()) {
+      val actTriggeredBySwipe = hasCrossedSwipeThreshold()
+      if (actEnabled && (actTriggeredBySwipe || cantDetermineSwiped)) {
         visibleAction?.let { action ->
           swipedAction = action
           action.value.onSwipe()
-          ripple.animate(action = action)
+
+          if(actTriggeredBySwipe) {
+            ripple.animate(action = action)
+          }
         }
       }
     }
+
     launch {
       draggableState.drag(MutatePriority.PreventUserInput) {
         Animatable(offsetState.value).animateTo(

--- a/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsState.kt
+++ b/library/src/commonMain/kotlin/me/saket/swipe/SwipeableActionsState.kt
@@ -64,9 +64,7 @@ class SwipeableActionsState internal constructor() {
       || (targetOffset > 0f && canSwipeTowardsRight)
       || (targetOffset < 0f && canSwipeTowardsLeft)
 
-    offsetState.value += if(isResettingOnRelease.not() && visibleAction?.value?.enableAnimation == false) 0f
-    else if (isAllowed) delta
-    else (delta / 10)
+    offsetState.value += if (isAllowed) delta else (delta / 10)
   }
 
   internal fun hasCrossedSwipeThreshold(): Boolean {
@@ -74,18 +72,16 @@ class SwipeableActionsState internal constructor() {
   }
 
   internal suspend fun handleOnDragStopped() = coroutineScope {
-    // if disable animation will not be able to determine swiped by offset
-    val cantDetermineSwiped = visibleAction?.value?.enableAnimation == false
+    val animationEnabled = visibleAction?.value?.enableAnimation == true
     val actEnabled = visibleAction?.value?.enableAct == true
 
     launch {
-      val actTriggeredBySwipe = hasCrossedSwipeThreshold()
-      if (actEnabled && (actTriggeredBySwipe || cantDetermineSwiped)) {
+      if (actEnabled && hasCrossedSwipeThreshold()) {
         visibleAction?.let { action ->
           swipedAction = action
           action.value.onSwipe()
 
-          if(actTriggeredBySwipe) {
+          if(animationEnabled) {
             ripple.animate(action = action)
           }
         }
@@ -93,14 +89,18 @@ class SwipeableActionsState internal constructor() {
     }
 
     launch {
-      draggableState.drag(MutatePriority.PreventUserInput) {
-        Animatable(offsetState.value).animateTo(
-          targetValue = 0f,
-          animationSpec = tween(durationMillis = animationDurationMs),
-        ) {
-          dragBy(value - offsetState.value)
+      if(animationEnabled) {
+        // here call drag is for keep the position correct when animating, if no animate then no need call drag
+        draggableState.drag(MutatePriority.PreventUserInput) {
+          Animatable(offsetState.value).animateTo(
+            targetValue = 0f,
+            animationSpec = tween(durationMillis = animationDurationMs),
+          ) {
+            dragBy(value - offsetState.value)
+          }
         }
       }
+
       swipedAction = null
     }
   }


### PR DESCRIPTION
### changes: 
- applied pr #33

### change `SwipeAction`:
  - add `enableAnimation` to control enable/disable animation
  - add `enableAct` to control enable/disable `onSwipe`
  - add `enableVibration` to control enable/disable vibration

### known bug: the  swipe animation of empty action list will not work

### A demo video, it disabled animation for swipe left to right but enable the action:
https://github.com/user-attachments/assets/59677148-e1ec-4c00-880e-1486c026f34e


